### PR TITLE
Greenlist

### DIFF
--- a/lib/beat_box.rb
+++ b/lib/beat_box.rb
@@ -16,7 +16,7 @@ class BeatBox
   end
 
   def play
-    beats = self.list.to_string
+    beats = list.to_string
     `say -r 500 -v Boing #{beats}`
   end
 end

--- a/lib/beat_box.rb
+++ b/lib/beat_box.rb
@@ -1,7 +1,10 @@
 class BeatBox
   attr_reader :list
-  def initialize
+  def initialize(head = nil)
     @list = LinkedList.new
+    if head != nil
+      @list.append(head)
+    end
   end
 
   def append(string)
@@ -19,4 +22,16 @@ class BeatBox
     beats = list.to_string
     `say -r 500 -v Boing #{beats}`
   end
+
+  def all
+    @list.to_string
+  end
+
+  def prepend(string)
+    sound_array = string.split(" ").reverse
+    sound_array.each do |sound|
+      @list.prepend(sound)
+    end
+  end
+
 end

--- a/lib/greenlist.rb
+++ b/lib/greenlist.rb
@@ -1,0 +1,6 @@
+class Greenlist
+  attr_reader :sounds
+  def initialize
+    @sounds = ["tee", "dee", "deep", "bop", "boop", "la", "na",]
+  end
+end

--- a/lib/greenlist.rb
+++ b/lib/greenlist.rb
@@ -8,4 +8,13 @@ class Greenlist
     sounds_array = sounds.split(" ")
     @sounds += sounds_array
   end
+
+  def remove_sounds (sounds)
+    sounds_array = sounds.split(" ")
+    sounds_array.each do |sound|
+      if @sounds.include?(sound)
+        @sounds.delete(sound)
+      end
+    end
+  end
 end

--- a/lib/greenlist.rb
+++ b/lib/greenlist.rb
@@ -1,7 +1,7 @@
 class Greenlist
   attr_reader :sounds
   def initialize
-    @sounds = ["tee", "dee", "deep", "bop", "boop", "la", "na",]
+    @sounds = ["tee", "dee", "deep", "bop", "boop", "la", "na", "doop", "plop", "suu", "dop", "woo", "shi", "shu", "blop"]
   end
 
   def add_sounds(sounds)

--- a/lib/greenlist.rb
+++ b/lib/greenlist.rb
@@ -1,7 +1,7 @@
 class Greenlist
   attr_reader :sounds
   def initialize
-    @sounds = ["tee", "dee", "deep", "bop", "boop", "la", "na", "doop", "plop", "suu", "dop", "woo", "shi", "shu", "blop"]
+    @sounds = ["tee", "dee", "deep", "bop", "boop", "la", "na", "doop", "plop", "suu", "dop", "woo", "shi", "shu", "blop", "dit", "doo", "hoo", "ditt"]
   end
 
   def add_sounds(sounds)

--- a/lib/greenlist.rb
+++ b/lib/greenlist.rb
@@ -3,4 +3,9 @@ class Greenlist
   def initialize
     @sounds = ["tee", "dee", "deep", "bop", "boop", "la", "na",]
   end
+
+  def add_sounds(sounds)
+    sounds_array = sounds.split(" ")
+    @sounds += sounds_array
+  end
 end

--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -1,4 +1,5 @@
 require './lib/node'
+require './lib/greenlist'
 
 class LinkedList
   attr_reader :head, :test

--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -130,19 +130,20 @@ class LinkedList
   end
 
   def pop
-    if @head.next_node == nil
-      data = @head.data
-      @head = nil
-      data
-    else
-      current_node = @head
-      until current_node.next_node.next_node == nil
-        current_node = current_node.next_node
+    if count != 0
+      if @head.next_node == nil
+        data = @head.data
+        @head = nil
+        data
+      else
+        current_node = @head
+        until current_node.next_node.next_node == nil
+          current_node = current_node.next_node
+        end
+        data = current_node.next_node.data
+        current_node.next_node = nil
+        data
       end
-      data = current_node.next_node.data
-      current_node.next_node = nil
-      data
     end
   end
-
 end

--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -2,6 +2,7 @@ require './lib/node'
 require './lib/greenlist'
 
 class LinkedList
+  @@greenlist = Greenlist.new
   attr_reader :head, :test
   def initialize
     @head = nil
@@ -9,15 +10,25 @@ class LinkedList
   end
 
   def append(data)
-    if @head == nil
-      @head = Node.new(data)
-    else
-      current_node = @head
-      until current_node.next_node == nil
-        current_node = current_node.next_node
+    if @@greenlist.sounds.include?(data)
+      if @head == nil
+        @head = Node.new(data)
+      else
+        current_node = @head
+        until current_node.next_node == nil
+          current_node = current_node.next_node
+        end
+        current_node.next_node = Node.new(data)
       end
-      current_node.next_node = Node.new(data)
     end
+  end
+
+  def greenlist_add(sounds)
+    @@greenlist.add_sounds(sounds)
+  end
+
+  def greenlist_remove(sounds)
+    @@greenlist.remove_sounds(sounds)
   end
 
   def count
@@ -52,28 +63,32 @@ class LinkedList
   end
 
   def prepend(data)
-    if @head == nil
-      @head = Node.new(data)
-    else
-      node = Node.new(data)
-      node.next_node = @head
-      @head = node
+    if @@greenlist.sounds.include?(data)
+      if @head == nil
+        @head = Node.new(data)
+      else
+        node = Node.new(data)
+        node.next_node = @head
+        @head = node
+      end
     end
   end
 
   def insert(index, data)
-    if index == 0
-      prepend(data)
-    else
-      current_node = @head
-      current_index = 0
-      until current_index == (index-1)
-        current_node = current_node.next_node
-        current_index += 1
+    if @@greenlist.sounds.include?(data)
+      if index == 0
+        prepend(data)
+      else
+        current_node = @head
+        current_index = 0
+        until current_index == (index-1)
+          current_node = current_node.next_node
+          current_index += 1
+        end
+        node = Node.new(data)
+        node.next_node = current_node.next_node
+        current_node.next_node = node
       end
-      node = Node.new(data)
-      node.next_node = current_node.next_node
-      current_node.next_node = node
     end
   end
 

--- a/spec/beat_box_spec.rb
+++ b/spec/beat_box_spec.rb
@@ -1,6 +1,7 @@
 require './lib/beat_box'
 require './lib/linked_list'
 require './lib/node'
+require './lib/greenlist'
 
 RSpec.describe BeatBox do
   describe '#initialize' do

--- a/spec/beat_box_spec.rb
+++ b/spec/beat_box_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe BeatBox do
       expect(bb.list).to be_an_instance_of(LinkedList)
       expect(bb.list.head).to eq(nil)
     end
+
+    it 'can take an argument and create a head' do
+      bb = BeatBox.new("deep")
+      expect(bb.all).to eq ("deep")
+    end 
   end
 
   describe '#append' do
@@ -26,6 +31,25 @@ RSpec.describe BeatBox do
 
       expect(bb.list.head.data).to eq("deep")
       expect(bb.list.head.next_node.data).to eq("doo")
+    end
+
+    it 'can only add sounds from greenlist' do
+      bb = BeatBox.new("deep")
+      bb.append("Mississippi")
+      expect(bb.all).to eq("deep")
+
+      bb.prepend("tee tee tee Mississippi")
+      expect(bb.all).to eq("tee tee tee deep")
+    end
+  end
+
+  describe '#prepend' do
+    it 'can add multiple nodes from one string to the beginning of a linked list' do
+      bb = BeatBox.new
+      bb.append("deep doo dit")
+      bb.prepend("woo hoo shu")
+
+      expect(bb.all).to eq ("woo hoo shu deep doo dit")
     end
   end
 
@@ -47,6 +71,16 @@ RSpec.describe BeatBox do
       expect(bb.list.count).to eq(6)
 
       expect(bb.play).to eq('')
+    end
+  end
+
+  describe '#all' do
+    it 'can list all sounds in beat box linked list' do
+      bb = BeatBox.new
+      bb.append("deep doo dit")
+      bb.append("woo hoo shu")
+
+      expect(bb.all).to eq("deep doo dit woo hoo shu")
     end
   end
 end

--- a/spec/greenlist_spec.rb
+++ b/spec/greenlist_spec.rb
@@ -5,12 +5,13 @@ RSpec.describe Greenlist do
     it 'is an instance of greenlist' do
       greenlist = Greenlist.new
 
-      expect(greenlist).to be_an_instance_of(Greenist)
+      expect(greenlist).to be_an_instance_of(Greenlist)
     end
 
     it 'has a starter greenlist when created' do
-      list = LinkedList.new
+      greenlist = Greenlist.new
 
       expect(greenlist.sounds).to eq(["tee", "dee", "deep", "bop", "boop", "la", "na",])
     end
   end
+end

--- a/spec/greenlist_spec.rb
+++ b/spec/greenlist_spec.rb
@@ -30,4 +30,20 @@ RSpec.describe Greenlist do
       expect(greenlist.sounds).to eq(["tee", "dee", "deep", "bop", "boop", "la", "na", "boom", "bam"])
     end
   end
+
+  describe '#remove_sounds' do
+    it 'can remove sounds from greenlist' do
+      greenlist = Greenlist.new
+      greenlist.remove_sounds("la")
+
+      expect(greenlist.sounds).to eq(["tee", "dee", "deep", "bop", "boop", "na"])
+    end
+
+    it 'can remove multiple sounds from greenlist' do
+      greenlist = Greenlist.new
+      greenlist.add_sounds("dee la")
+
+      expect(greenlist.sounds).to eq(["tee", "deep", "bop", "boop", "na"])
+    end
+  end
 end

--- a/spec/greenlist_spec.rb
+++ b/spec/greenlist_spec.rb
@@ -11,7 +11,23 @@ RSpec.describe Greenlist do
     it 'has a starter greenlist when created' do
       greenlist = Greenlist.new
 
-      expect(greenlist.sounds).to eq(["tee", "dee", "deep", "bop", "boop", "la", "na",])
+      expect(greenlist.sounds).to eq(["tee", "dee", "deep", "bop", "boop", "la", "na"])
+    end
+  end
+
+  describe '#add_sounds' do
+    it 'can add new sounds to greenlist' do
+      greenlist = Greenlist.new
+      greenlist.add_sounds("boom")
+
+      expect(greenlist.sounds).to eq(["tee", "dee", "deep", "bop", "boop", "la", "na", "boom"])
+    end
+
+    it 'can add multiple sounds to greenlist' do
+      greenlist = Greenlist.new
+      greenlist.add_sounds("boom bam")
+
+      expect(greenlist.sounds).to eq(["tee", "dee", "deep", "bop", "boop", "la", "na", "boom", "bam"])
     end
   end
 end

--- a/spec/greenlist_spec.rb
+++ b/spec/greenlist_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Greenlist do
 
     it 'can remove multiple sounds from greenlist' do
       greenlist = Greenlist.new
-      greenlist.add_sounds("dee la")
+      greenlist.remove_sounds("dee la")
 
       expect(greenlist.sounds).to eq(["tee", "deep", "bop", "boop", "na"])
     end

--- a/spec/greenlist_spec.rb
+++ b/spec/greenlist_spec.rb
@@ -1,0 +1,16 @@
+require './lib/greenlist'
+
+RSpec.describe Greenlist do
+  describe '#initialize' do
+    it 'is an instance of greenlist' do
+      greenlist = Greenlist.new
+
+      expect(greenlist).to be_an_instance_of(Greenist)
+    end
+
+    it 'has a starter greenlist when created' do
+      list = LinkedList.new
+
+      expect(greenlist.sounds).to eq(["tee", "dee", "deep", "bop", "boop", "la", "na",])
+    end
+  end

--- a/spec/linked_list_spec.rb
+++ b/spec/linked_list_spec.rb
@@ -1,5 +1,6 @@
 require './lib/node'
 require './lib/linked_list'
+require './lib/greenlist'
 
 RSpec.describe LinkedList do
   describe '#initialize' do


### PR DESCRIPTION
The beatbox can now only add nodes that are on the greenlist class. Two minor BeatBox class methods have also been added : prepend, which adds nodes to the beginning of the linked list ; all, which prints all the nodes to a string. The initialize method can now take a string as an argument to make a head node