### PR TITLE
Feat/play modifiers

### DIFF
--- a/lib/beat_box.rb
+++ b/lib/beat_box.rb
@@ -1,10 +1,14 @@
 class BeatBox
   attr_reader :list
+  attr_writer :rate
+  attr_writer :voice
   def initialize(head = nil)
     @list = LinkedList.new
     if head != nil
-      @list.append(head)
+      self.append(head)
     end
+    @rate = 500
+    @voice = "Boing"
   end
 
   def append(string)
@@ -20,7 +24,7 @@ class BeatBox
 
   def play
     beats = list.to_string
-    `say -r 500 -v Boing #{beats}`
+    `say -r #{@rate.to_s} -v #{@voice} #{beats}`
   end
 
   def all
@@ -32,6 +36,14 @@ class BeatBox
     sound_array.each do |sound|
       @list.prepend(sound)
     end
+  end
+
+  def reset_rate
+    @rate = 500
+  end
+
+  def reset_voice
+    voice = "Boing"
   end
 
 end

--- a/lib/beat_box.rb
+++ b/lib/beat_box.rb
@@ -43,7 +43,7 @@ class BeatBox
   end
 
   def reset_voice
-    voice = "Boing"
+    @voice = "Boing"
   end
 
 end

--- a/spec/beat_box_spec.rb
+++ b/spec/beat_box_spec.rb
@@ -83,6 +83,43 @@ RSpec.describe BeatBox do
       expect(bb.all).to eq("deep doo dit woo hoo shu")
     end
   end
+
+  describe '#rate and #reset_rate' do
+    it 'can change the speed at which sounds are played' do
+      bb = BeatBox.new("deep dop dop deep")
+      bb.play
+      bb.rate = 100
+
+      expect(bb.all).to eq(4)
+    end
+
+    it 'can reset the rate to the default' do
+      bb = BeatBox.new("deep dop dop deep")
+      bb.rate = 100
+      bb.play
+      bb.reset_rate
+
+      expect(bb.all).to eq(4)
+  end
+
+  describe '#voice and #reset_voice' do
+    it 'can change the Voice in which sounds are played' do
+      bb = BeatBox.new("deep dop dop deep")
+      bb.play
+      bb.voice = "Daniel"
+
+      expect(bb.play).to eq(4)
+    end
+
+    it 'can reset the voice to the default' do
+      bb = BeatBox.new("deep dop dop deep")
+      bb.voice = 'Daniel'
+      bb.play
+      bb.reset_voice
+
+      expect(bb.play).to eq(4)
+    end
+  end
 end
 
 

--- a/spec/beat_box_spec.rb
+++ b/spec/beat_box_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe BeatBox do
       expect(bb.count).to eq(6)
       expect(bb.list.count).to eq(6)
 
-      expect(bb.play).to eq('')
+      expect(bb).to receive(:`).with('say -r 500 -v Boing deep doo ditt woo hoo shu')
+      bb.play
     end
   end
 
@@ -90,7 +91,8 @@ RSpec.describe BeatBox do
       bb.play
       bb.rate = 100
 
-      expect(bb.play).to eq("")
+      expect(bb).to receive(:`).with('say -r 100 -v Boing deep dop dop deep')
+      bb.play
     end
 
     it 'can reset the rate to the default' do
@@ -99,7 +101,8 @@ RSpec.describe BeatBox do
       bb.play
       bb.reset_rate
 
-      expect(bb.play).to eq("")
+      expect(bb).to receive(:`).with('say -r 500 -v Boing deep dop dop deep')
+      bb.play
     end
   end
 
@@ -109,7 +112,8 @@ RSpec.describe BeatBox do
       bb.play
       bb.voice = "Daniel"
 
-      expect(bb.play).to eq("")
+      expect(bb).to receive(:`).with('say -r 500 -v Daniel deep dop dop deep')
+      bb.play
     end
 
     it 'can reset the voice to the default' do
@@ -118,7 +122,8 @@ RSpec.describe BeatBox do
       bb.play
       bb.reset_voice
 
-      expect(bb.play).to eq("")
+      expect(bb).to receive(:`).with('say -r 500 -v Boing deep dop dop deep')
+      bb.play
     end
   end
 end

--- a/spec/beat_box_spec.rb
+++ b/spec/beat_box_spec.rb
@@ -85,12 +85,12 @@ RSpec.describe BeatBox do
   end
 
   describe '#rate and #reset_rate' do
-    xit 'can change the speed at which sounds are played' do
+    it 'can change the speed at which sounds are played' do
       bb = BeatBox.new("deep dop dop deep")
       bb.play
       bb.rate = 100
 
-      expect(bb.all).to eq(4)
+      expect(bb.play).to eq("")
     end
 
     it 'can reset the rate to the default' do
@@ -99,29 +99,26 @@ RSpec.describe BeatBox do
       bb.play
       bb.reset_rate
 
-      expect(bb.all).to eq(4)
+      expect(bb.play).to eq("")
     end
   end
 
   describe '#voice and #reset_voice' do
-    xit 'can change the Voice in which sounds are played' do
+    it 'can change the Voice in which sounds are played' do
       bb = BeatBox.new("deep dop dop deep")
       bb.play
       bb.voice = "Daniel"
 
-      expect(bb.play).to eq(4)
+      expect(bb.play).to eq("")
     end
 
-    xit 'can reset the voice to the default' do
+    it 'can reset the voice to the default' do
       bb = BeatBox.new("deep dop dop deep")
       bb.voice = 'Daniel'
       bb.play
       bb.reset_voice
 
-      expect(bb.play).to eq(4)
+      expect(bb.play).to eq("")
     end
   end
 end
-
-
-

--- a/spec/beat_box_spec.rb
+++ b/spec/beat_box_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe BeatBox do
   end
 
   describe '#rate and #reset_rate' do
-    it 'can change the speed at which sounds are played' do
+    xit 'can change the speed at which sounds are played' do
       bb = BeatBox.new("deep dop dop deep")
       bb.play
       bb.rate = 100
@@ -100,10 +100,11 @@ RSpec.describe BeatBox do
       bb.reset_rate
 
       expect(bb.all).to eq(4)
+    end
   end
 
   describe '#voice and #reset_voice' do
-    it 'can change the Voice in which sounds are played' do
+    xit 'can change the Voice in which sounds are played' do
       bb = BeatBox.new("deep dop dop deep")
       bb.play
       bb.voice = "Daniel"
@@ -111,7 +112,7 @@ RSpec.describe BeatBox do
       expect(bb.play).to eq(4)
     end
 
-    it 'can reset the voice to the default' do
+    xit 'can reset the voice to the default' do
       bb = BeatBox.new("deep dop dop deep")
       bb.voice = 'Daniel'
       bb.play


### PR DESCRIPTION
First - Allowed Beatbox to take on a string of multiple sounds as an argument to make multiple nodes.

Second - Using Iteration 4 interaction pattern to build tests- this branch adds some customizability to the play method.
-The voice used for the play can be changed and reset to the default using the voice attr_writer and the voice_reset method.
-The rate at which the voice is played can be changed through an attr_writer and reset to the defaut using the rate_reset method